### PR TITLE
Tiny typo in installation instructions

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -28,7 +28,7 @@ You can install the development version of adodown like so:
 
 ``` r
 if (!require("devtools")) install.packages("devtools")
-devtools::install_gihub("arthur-shaw/adodown")
+devtools::install_github("arthur-shaw/adodown")
 ```
 
 ## Usage

--- a/README.Rmd
+++ b/README.Rmd
@@ -70,3 +70,4 @@ This package draws heavy inspiration from two packages:
 
 - [pkgdown](https://github.com/r-lib/pkgdown/), the best known R package for documentation websites
 - [ecodown](https://github.com/edgararuiz/ecodown), an experimental effort to use Quarto for the same purpose
+


### PR DESCRIPTION
Tiny typo in installation instructions.

Edits on line 72 is just that editor on GitHub.com use different line ending character or end of line character