### PR TITLE
Exclude adodown-created README.md files from site

### DIFF
--- a/man/build_files.Rd
+++ b/man/build_files.Rd
@@ -4,10 +4,13 @@
 \alias{build_files}
 \title{Build Quarto files from Markdown}
 \usage{
-build_files(dir_in, dir_out)
+build_files(dir_in, exclude = NULL, dir_out)
 }
 \arguments{
 \item{dir_in}{Character. Source package directory where files are located.}
+
+\item{exclude}{Character. Files to exclude from building process.
+Specified as a regular expression.}
 
 \item{dir_out}{Character. Target site directory where files are written.}
 }

--- a/man/build_reference_index.Rd
+++ b/man/build_reference_index.Rd
@@ -4,10 +4,13 @@
 \alias{build_reference_index}
 \title{Build reference index from files in source package help folder}
 \usage{
-build_reference_index(dir_in, dir_out)
+build_reference_index(dir_in, exclude = NULL, dir_out)
 }
 \arguments{
 \item{dir_in}{Character. Help/reference file folder of source package.}
+
+\item{exclude}{Character. Files to exclude from building process.
+Specified as a regular expression.}
 
 \item{dir_out}{Character. Reference foler of target documentation site.}
 }


### PR DESCRIPTION
This PR does so by:

- Providing an `exclude` param for relevant functions that build
- Specify README.md for those functions