### PR TITLE
Build site even if `src/dev/assets` doesn't exist

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -200,29 +200,35 @@ build_site <- function(
     }
 
     # copy stylesheets, if they exist in package folder
+    # and if the assets folder exists
     style_dir <- fs::path(pkg_dir, "src", "dev", "assets")
-    # css
-    css_files <- fs::dir_ls(path = style_dir, regexp = "\\.css") |>
-        fs::path_file()
-    if (length(css_files)) {
+    style_dir_exists <- fs::dir_exists(style_dir)
 
-        fs::file_copy(
-            path = fs::path(style_dir, css_files),
-            new_path = fs::path(site_dir, "style", css_files)
-        )
+    if (style_dir_exists) {
+        
+        # css
+        css_files <- fs::dir_ls(path = style_dir, regexp = "\\.css") |>
+            fs::path_file()
+        if (length(css_files)) {
 
-    }
+            fs::file_copy(
+                path = fs::path(style_dir, css_files),
+                new_path = fs::path(site_dir, "style", css_files)
+            )
 
-    # scss
-    scss_files <- fs::dir_ls(path = style_dir, regexp = "\\.scss") |>
-        fs::path_file()
-    if (length(scss_files)) {
+        }
 
-        fs::file_copy(
-            path = fs::path(style_dir, scss_files),
-            new_path = fs::path(site_dir, "style", scss_files)
-        )
+        # scss
+        scss_files <- fs::dir_ls(path = style_dir, regexp = "\\.scss") |>
+            fs::path_file()
+        if (length(scss_files)) {
 
+            fs::file_copy(
+                path = fs::path(style_dir, scss_files),
+                new_path = fs::path(site_dir, "style", scss_files)
+            )
+
+        }
     }
 
     # create YAML

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -156,16 +156,24 @@ compose_quarto_yaml <- function(
     # determine whether CSS and/or SCSS files exist
     style_dir <- fs::path(pkg_dir, "src", "dev", "assets")
     # css
-    css_paths <- fs::dir_ls(path = style_dir, regexp = "\\.css")
+    css_paths <- ifelse(
+        test = fs::dir_exists(style_dir),
+        yes = fs::dir_ls(path = style_dir, regexp = "\\.css"),
+        no = character()
+    )
     has_css <- ifelse(
-        test = length(css_paths) > 0,
+        test = !is.na(css_paths) & length(css_paths) > 0,
         yes = TRUE,
         no = FALSE
     )
     # scss
-    scss_paths <- fs::dir_ls(path = style_dir, regexp = "\\.scss")
+    scss_paths <- ifelse(
+        test = fs::dir_exists(style_dir),
+        yes = fs::dir_ls(path = style_dir, regexp = "\\.scss"),
+        no = character()
+    )
     has_scss <- ifelse(
-        test = length(scss_paths) > 0,
+        test = !is.na(scss_paths) & length(scss_paths) > 0,
         yes = TRUE,
         no = FALSE
     )
@@ -185,7 +193,7 @@ compose_quarto_yaml <- function(
         spec$format$html$css <- NULL
 
     }
-    # css
+    # scss
     # keep default `cosmo` theme and add scss files, if applicable
     if (has_scss) {
 


### PR DESCRIPTION
Closes #26 

This PR adapts build logic to handle case where `src/dev/assets` doesn't exist. In particular, it:

- Skips build steps that pre-suppose the directory exists
- Handles non-existence of directory when composing YAML components that previously assumed the directory exists