### PR TITLE
Extract package name from pkg file name

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -105,7 +105,7 @@ get_cmd_short_desc <- function(file) {
 #' @param rm_old_site_dir Boolean. If `TRUE`, delete old site. Otherwise, keep
 #' but overwrite same-named files.
 #'
-#' @importFrom fs file_move path file_exists dir_ls file_copy
+#' @importFrom fs file_move path file_exists dir_ls file_copy path_file dir_exists
 #' @importFrom quarto quarto_path quarto_preview
 #'
 #' @export

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -66,11 +66,9 @@ get_pkg_metadata <- function(pkg_file_path) {
         header_text = "*** version", 
         entry_prefix = "v "
     )
-    name <- extract_metadata(
-        pkg_lines = pkg_lines,
-        header_text = "*** name",
-        entry_prefix = "d "
-    )
+    name <- pkg_file_path |>
+        fs::path_file() |>
+        fs::path_ext_remove()
     desc <- extract_metadata(
         pkg_lines = pkg_lines,
         header_text = "*** description", 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -47,6 +47,8 @@ find_file_in_pkg <- function(
 #' - `url`. URL of repository where package source code stored.
 #' - `date`.  Date current Stata package version released.
 #' 
+#' @importFrom fs path_file path_ext_remove
+#' 
 #' @noRd 
 get_pkg_metadata <- function(pkg_file_path) {
 


### PR DESCRIPTION
Closes #27 

This PR extracts the package name from the `.pkg` file name rather than from that file's contents.